### PR TITLE
Fix sentiment variable in SentimentModel score

### DIFF
--- a/sentiment/ml.py
+++ b/sentiment/ml.py
@@ -146,6 +146,7 @@ class SentimentModel(object):
         except Exception as e:
             logging.error("Failed on tweet: %s. Error: %s", text, str(e))
             scores = self.baseline
+            sentiment = np.array([[0.0]])
 
 
         scores = [float(s) for s in scores[0, :]]


### PR DESCRIPTION
## Summary
- avoid undefined `sentiment` when model prediction fails

## Testing
- `pytest -q`