### PR TITLE
Add deploy helper target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,7 @@ coverage-all:
 
 # Default
 all: setup
+
+# Deploy to Google App Engine
+deploy: build-frontend build-elm
+	gcloud app deploy app.yaml

--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ To set up automatic deployment, you need to:
 
 The GitHub Actions workflow in `.github/workflows/deploy.yml` will handle the rest, automatically deploying your application when changes are merged to the master branch.
 
+### Manual Deployment
+
+If you want to deploy manually using the Google Cloud SDK, make sure the compiled
+static assets are available. The provided Makefile includes a `deploy` target that
+builds the frontend and Elm assets and then runs `gcloud app deploy`:
+
+```bash
+make deploy
+```
+
+This command ensures that `static/dist` is populated before uploading the
+application to App Engine.
+
 ## Project Overview
 
 This Flask-based personal site combines traditional web technologies with modern approaches like Elm and machine learning.

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -1,0 +1,13 @@
+import subprocess
+import pytest
+
+pytestmark = pytest.mark.deploy
+
+
+def test_makefile_deploy_target():
+    """Ensure the deploy target builds assets and calls gcloud."""
+    result = subprocess.run(["make", "--dry-run", "deploy"], capture_output=True, text=True, check=False)
+    output = result.stdout
+    assert "npm run build" in output
+    assert "elm make" in output
+    assert "gcloud app deploy" in output


### PR DESCRIPTION
## Summary
- add a `deploy` command to Makefile to build assets and run `gcloud app deploy`
- document manual deployment in README
- test Makefile deploy target

## Testing
- `make test-backend`