### PR TITLE
Fix favicon handling on GAE

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, jsonify, request, url_for
+from flask import Flask, render_template, redirect, jsonify, request, url_for, send_from_directory
 import os
 import logging
 
@@ -125,6 +125,15 @@ def register_routes(app):
     @app.route("/")
     def index():
         return render_template("index.html")
+
+    # Serve the favicon for browsers that request /favicon.ico
+    @app.route("/favicon.ico")
+    def favicon():
+        return send_from_directory(
+            os.path.join(app.static_folder, "dist", "images"),
+            "favicon.png",
+            mimetype="image/png",
+        )
 
     @app.route("/contact")
     def contact():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -126,3 +126,9 @@ def test_debug_static_endpoint(client):
     for file_entry in data['files']:
         assert 'path' in file_entry
         assert 'url' in file_entry
+
+def test_favicon_route(client):
+    """Ensure the favicon route returns the icon"""
+    response = client.get('/favicon.ico')
+    assert response.status_code == 200
+    assert 'image' in response.headers['Content-Type']


### PR DESCRIPTION
## Summary
- add /favicon.ico route in Flask app so browsers can load the icon
- include `send_from_directory` import
- test the new favicon route

## Testing
- `make test-backend`