### PR TITLE
Add elm-test setup support and test directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Frontend Build Commands
 install-elm:
 	@which elm >/dev/null || npm install -g elm
+	@which elm-test >/dev/null || npm install -g elm-test
 
 install-frontend: install-elm
 	cd frontend && npm install

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ make build-elm
 make dev-elm
 ```
 
-Note: Elm must be installed globally (`npm install -g elm`) for the build commands to work.
+Note: Elm and `elm-test` must be installed globally for the build and test commands to work. `make setup` will install them automatically if they are missing.
 
 ### Frontend Testing
 


### PR DESCRIPTION
## Summary
- ensure `elm-test` is installed via `make setup`
- note elm-test install requirement in README
- add an empty `elm/tests` directory for future Elm tests

## Testing
- `make test-backend`