### PR TITLE
Fix favicon route fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, jsonify, request, url_for, send_from_directory
+from flask import Flask, render_template, redirect, jsonify, request, url_for, send_from_directory, abort
 import os
 import logging
 
@@ -129,11 +129,16 @@ def register_routes(app):
     # Serve the favicon for browsers that request /favicon.ico
     @app.route("/favicon.ico")
     def favicon():
-        return send_from_directory(
-            os.path.join(app.static_folder, "dist", "images"),
-            "favicon.png",
-            mimetype="image/png",
-        )
+        """Serve the favicon from the built assets if available."""
+        dist_dir = os.path.join(app.static_folder, "dist", "images")
+        fallback_dir = os.path.join(app.static_folder, "images")
+
+        if os.path.exists(os.path.join(dist_dir, "favicon.png")):
+            return send_from_directory(dist_dir, "favicon.png", mimetype="image/png")
+        elif os.path.exists(os.path.join(fallback_dir, "favicon.png")):
+            return send_from_directory(fallback_dir, "favicon.png", mimetype="image/png")
+
+        return abort(404)
 
     @app.route("/contact")
     def contact():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -132,3 +132,19 @@ def test_favicon_route(client):
     response = client.get('/favicon.ico')
     assert response.status_code == 200
     assert 'image' in response.headers['Content-Type']
+
+
+def test_favicon_route_fallback(client, monkeypatch):
+    """Favicon route should fall back to non-dist asset when dist file is missing."""
+    dist_path = os.path.join(current_app.static_folder, 'dist', 'images', 'favicon.png')
+
+    real_exists = os.path.exists
+
+    def fake_exists(path):
+        if path == dist_path:
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(os.path, 'exists', fake_exists)
+    response = client.get('/favicon.ico')
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- serve `/favicon.ico` from built assets if present or fall back to `static/images`
- add regression test covering fallback logic

## Testing
- `make test-backend`