### PR TITLE
Fix local setup for virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,13 @@ test-frontend-coverage:
 # Backend Setup Commands
 install-python-deps:
 	@which uv >/dev/null || pip install uv
-	uv pip install --system -r requirements.txt 
-	uv pip install --system -e .[dev]
+	@if [ -n "$$VIRTUAL_ENV" ]; then \
+	uv pip install -r requirements.txt; \
+	uv pip install -e .[dev]; \
+	else \
+	uv pip install --system -r requirements.txt; \
+	uv pip install --system -e .[dev]; \
+	fi
 
 # Backend Test Commands
 test-backend:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ make setup
 make run-app
 ```
 
+`make setup` detects if a virtual environment is active. When `VIRTUAL_ENV`
+is set (e.g. after running `source venv/bin/activate`), dependencies are
+installed into that environment. Otherwise packages are installed system wide,
+which is useful in the cloud workspace.
+
 Then visit http://localhost:5000 in your browser.
 
 ## Testing


### PR DESCRIPTION
## Summary
- install python deps inside an active virtualenv if present
- clarify README that `make setup` installs into the active virtualenv

## Testing
- `make test-backend`