### PR TITLE
Add favicon fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -129,8 +129,17 @@ def register_routes(app):
     # Serve the favicon for browsers that request /favicon.ico
     @app.route("/favicon.ico")
     def favicon():
+        """Serve favicon from dist if available, else fall back to images."""
+        dist_path = os.path.join(app.static_folder, "dist", "images", "favicon.png")
+        if os.path.exists(dist_path):
+            return send_from_directory(
+                os.path.join(app.static_folder, "dist", "images"),
+                "favicon.png",
+                mimetype="image/png",
+            )
+        # Fall back to the non-dist image
         return send_from_directory(
-            os.path.join(app.static_folder, "dist", "images"),
+            os.path.join(app.static_folder, "images"),
             "favicon.png",
             mimetype="image/png",
         )

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,7 +47,7 @@
 
   <!-- Favicon
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="icon" type="image/png" href="{{ url_for('static', filename='dist/images/favicon.png') }}">
+  <link rel="icon" type="image/png" href="{{ url_for('favicon') }}">
   {% endblock %}
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -133,3 +133,25 @@ def test_favicon_route(client):
     assert response.status_code == 200
     assert 'image' in response.headers['Content-Type']
 
+
+def test_favicon_fallback(client, monkeypatch):
+    """Ensure the favicon route falls back when dist icon is missing."""
+    dist_path = os.path.join(current_app.static_folder, 'dist', 'images', 'favicon.png')
+    fallback_path = os.path.join(current_app.static_folder, 'images', 'favicon.png')
+
+    real_exists = os.path.exists
+
+    def fake_exists(path):
+        if path == dist_path:
+            return False
+        return real_exists(path)
+
+    monkeypatch.setattr(os.path, 'exists', fake_exists)
+
+    with open(fallback_path, 'rb') as f:
+        expected_data = f.read()
+
+    response = client.get('/favicon.ico')
+    assert response.status_code == 200
+    assert response.data == expected_data
+


### PR DESCRIPTION
## Summary
- support fallback for favicon route
- use `/favicon.ico` path in base template
- test favicon fallback logic

## Testing
- `make test-backend`