### PR TITLE
Add curl plaintext for index

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,17 @@ from sentiment.emojis import emojis
 # Initialize sentiment model lazily when needed
 _sentiment_model = None
 
+# Plain text used for curl requests on the about and index pages
+ABOUT_TEXT = """
+I'm Eric Kramer. I currently work at OpenAI helping build the developer platform.
+I used to work at Stripe and Dataiku. A long time ago, I was an MD/PhD student at
+UC San Diego.
+
+I live in Noe Valley, San Francisco with my wife, our two cats and two sons.
+Get in touch if you want to talk more about data science or medicine. You
+can reach me at 619.724.3800 or ericransomkramer@gmail.com.
+"""
+
 
 def get_sentiment_model():
     global _sentiment_model
@@ -124,6 +135,9 @@ def register_routes(app):
     # Main site routes
     @app.route("/")
     def index():
+        user_agent = request.headers.get("User-Agent", "").lower()
+        if "curl" in user_agent:
+            return ABOUT_TEXT
         return render_template("index.html")
 
     # Serve the favicon for browsers that request /favicon.ico
@@ -157,18 +171,7 @@ def register_routes(app):
         user_agent = request.headers.get("User-Agent", "").lower()
         if "curl" in user_agent:
             # Plain text version for curl requests
-            return """
-
-I'm Eric Kramer. I currently work at OpenAI helping build the developer platform. 
-I used to work at Stripe and Dataiku. A long time ago, I was an MD/PhD student at 
-UC San Diego.
-
-
-I live in Noe Valley, San Francisco with my wife, our two cats and two sons.
-Get in touch if you want to talk more about data science or medicine. You 
-can reach me at 619.724.3800 or ericransomkramer@gmail.com.
-
-"""
+            return ABOUT_TEXT
         else:
             return render_template("about.html")
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,6 +2,7 @@ import pytest
 import os
 from flask import url_for, current_app
 from bs4 import BeautifulSoup
+from app import ABOUT_TEXT
 
 pytestmark = pytest.mark.routes
 
@@ -10,6 +11,14 @@ def test_index_route(client):
     response = client.get('/')
     assert response.status_code == 200
     assert b'html' in response.data
+
+def test_index_route_curl(client):
+    """Index route should return about text when accessed via curl."""
+    response = client.get('/', headers={'User-Agent': 'curl/7.79.1'})
+    assert response.status_code == 200
+    text = response.get_data(as_text=True)
+    assert ABOUT_TEXT.strip() in text
+    assert '<' not in text
     
 def test_index_svg_links(client):
     """Test that the SVG links in index.html are properly formatted and link to the right routes."""


### PR DESCRIPTION
## Summary
- refactor about page text into ABOUT_TEXT constant
- return ABOUT_TEXT when hitting index or about with curl
- test the new behavior

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6849af54a3e48329811820014812baea