### PR TITLE
Lazy-load TensorFlow model

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,6 @@ from models import db
 from config import config
 
 # Import sentiment-related modules
-from sentiment.ml import SentimentModel
 from sentiment.emojis import emojis
 
 # Initialize sentiment model lazily when needed


### PR DESCRIPTION
## Summary
- avoid importing TensorFlow on startup by removing `SentimentModel` global import
- keep tests passing

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6849af0a77088329b75637c47be76a0a