### PR TITLE
Add curl links to homepage text

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,7 +136,13 @@ def register_routes(app):
     def index():
         user_agent = request.headers.get("User-Agent", "").lower()
         if "curl" in user_agent:
-            return ABOUT_TEXT
+            links = "\n".join([
+                f"- home: {url_for('index')}",
+                f"- about: {url_for('about')}",
+                f"- demos: {url_for('demos')}",
+                f"- contact: {url_for('contact')}",
+            ])
+            return f"{ABOUT_TEXT.strip()}\n\n{links}\n"
         return render_template("index.html")
 
     # Serve the favicon for browsers that request /favicon.ico

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,6 +18,13 @@ def test_index_route_curl(client):
     assert response.status_code == 200
     text = response.get_data(as_text=True)
     assert ABOUT_TEXT.strip() in text
+    for line in [
+        "- home: /",
+        "- about: /about",
+        "- demos: /demos",
+        "- contact: /contact",
+    ]:
+        assert line in text
     assert '<' not in text
     
 def test_index_svg_links(client):


### PR DESCRIPTION
## Summary
- when using curl on the homepage, also return useful links
- update route tests for new output

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6851ab4316248329ac462c735438ed5a