### PR TITLE
Improve terminal curl output

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,9 @@ from sentiment.emojis import emojis
 # Initialize sentiment model lazily when needed
 _sentiment_model = None
 
+# Base URL used when generating hyperlinks for terminal output
+BASE_URL = "https://erickramer.xyz"
+
 # Plain text used for curl requests on the about and index pages
 ABOUT_TEXT = """
 I'm Eric Kramer. I currently work at OpenAI helping build the developer platform.
@@ -24,6 +27,11 @@ I live in Noe Valley, San Francisco with my wife, our two cats and two sons.
 Get in touch if you want to talk more about data science or medicine. You
 can reach me at 619.724.3800 or ericransomkramer@gmail.com.
 """
+
+
+def hyperlink(text: str, url: str) -> str:
+    """Return OSC-8 hyperlink escape sequence."""
+    return f"\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\"
 
 
 def get_sentiment_model():
@@ -137,10 +145,11 @@ def register_routes(app):
         user_agent = request.headers.get("User-Agent", "").lower()
         if "curl" in user_agent:
             links = "\n".join([
-                f"- home: {url_for('index')}",
-                f"- about: {url_for('about')}",
-                f"- demos: {url_for('demos')}",
-                f"- contact: {url_for('contact')}",
+                f"- {hyperlink('home', BASE_URL + url_for('index'))}",
+                f"- {hyperlink('about', BASE_URL + url_for('about'))}",
+                f"- {hyperlink('demos', BASE_URL + url_for('demos'))}",
+                f"- {hyperlink('resume', BASE_URL + url_for('resume'))}",
+                f"- {hyperlink('contact', BASE_URL + url_for('contact'))}",
             ])
             return f"{ABOUT_TEXT.strip()}\n\n{links}\n"
         return render_template("index.html")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,13 +18,18 @@ def test_index_route_curl(client):
     assert response.status_code == 200
     text = response.get_data(as_text=True)
     assert ABOUT_TEXT.strip() in text
-    for line in [
-        "- home: /",
-        "- about: /about",
-        "- demos: /demos",
-        "- contact: /contact",
+    def osc8(label, path):
+        url = f"https://erickramer.xyz{path}"
+        return f"- \x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\"
+
+    for label, path in [
+        ("home", "/"),
+        ("about", "/about"),
+        ("demos", "/demos"),
+        ("resume", "/resume"),
+        ("contact", "/contact"),
     ]:
-        assert line in text
+        assert osc8(label, path) in text
     assert '<' not in text
     
 def test_index_svg_links(client):


### PR DESCRIPTION
## Summary
- add OSC-8 hyperlink helper and base URL constant
- return clickable links when curling the homepage
- update tests for new hyperlink output
- include resume link in terminal curl output

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6851b017556c8329bb714b63323e40f3