### PR TITLE
Add container-based deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+venv/
+node_modules/
+frontend/node_modules/
+tests/
+*.egg-info/
+.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,9 @@ jobs:
       with:
         version: ">= 363.0.0"
         project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+    - name: Configure Docker for Artifact Registry
+      run: gcloud auth configure-docker us-central1-docker.pkg.dev -q
       
     - name: Verify service account permissions
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use Python 3.9 slim image
+FROM python:3.9-slim AS builder
+
+WORKDIR /app
+
+# Install system packages for building assets
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nodejs npm curl && rm -rf /var/lib/apt/lists/*
+
+# Install Elm globally for asset compilation
+RUN npm install -g elm@0.19.1 elm-test@0.19.1-revision9
+
+# Copy dependency files
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Build frontend and Elm assets
+RUN make build-frontend && make build-elm
+
+# Final runtime image
+FROM python:3.9-slim
+WORKDIR /app
+
+# Copy installed packages and source from builder stage
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /app /app
+
+ENV PORT=8080
+EXPOSE 8080
+CMD ["gunicorn", "-b", "0.0.0.0:$PORT", "app:app"]

--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,10 @@ coverage-all:
 all: setup
 
 # Deploy to Google App Engine
+IMAGE ?= us-central1-docker.pkg.dev/$(GCP_PROJECT_ID)/personal-site/personal-site
+TAG ?= latest
+
 deploy: build-frontend build-elm
-	gcloud app deploy app.yaml
+	docker build -t $(IMAGE):$(TAG) .
+	docker push $(IMAGE):$(TAG)
+	gcloud app deploy app.yaml --image-url=$(IMAGE):$(TAG)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ which is useful in the cloud workspace.
 
 Then visit http://localhost:5000 in your browser.
 
+### Docker Image
+
+You can also run the application inside a container. Build the image using the
+provided `Dockerfile`:
+
+```bash
+docker build -t personal-site .
+docker run -p 8080:8080 -e PORT=8080 personal-site
+```
+
+This mirrors the image that GitHub Actions builds and pushes to Google Artifact
+Registry on every merge to `master`.
+
 ## Testing
 
 The application includes comprehensive test suites for both backend and frontend code.
@@ -109,13 +122,14 @@ To set up automatic deployment, you need to:
    - `GCP_PROJECT_ID`: Your Google Cloud Project ID
    - `GCP_SA_KEY`: The entire content of the downloaded Service Account JSON key file
 
-The GitHub Actions workflow in `.github/workflows/deploy.yml` will handle the rest, automatically deploying your application when changes are merged to the master branch. The workflow invokes the Makefile's `deploy` target so your static assets are built before `gcloud` uploads the app.
+The GitHub Actions workflow in `.github/workflows/deploy.yml` handles deployment whenever changes are merged to the `master` branch.  It builds a Docker image from the provided `Dockerfile`, pushes that image to Google Artifact Registry, and then invokes the Makefile's `deploy` target.  The deploy target in turn calls `gcloud app deploy --image-url` so App Engine runs the freshly built container.
 
 ### Manual Deployment
 
 If you want to deploy manually using the Google Cloud SDK, make sure the compiled
 static assets are available. The provided Makefile includes a `deploy` target that
-builds the frontend and Elm assets and then runs `gcloud app deploy`:
+builds the frontend and Elm assets, builds the Docker image and pushes it to Artifact
+Registry, and then runs `gcloud app deploy --image-url`:
 
 ```bash
 make deploy

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,5 @@
-runtime: python39
+runtime: custom
+env: flex
 entrypoint: gunicorn -b :$PORT app:app
 handlers:
 - url: /static


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore for container builds
- switch App Engine to custom runtime
- build & push container image in Makefile
- configure workflow to auth with Artifact Registry
- document container workflow

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6851b7c5545c8329834f643ae1170de0