### PR TITLE
Add blue curl links with intro text

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,9 +29,25 @@ can reach me at 619.724.3800 or ericransomkramer@gmail.com.
 """
 
 
-def hyperlink(text: str, url: str) -> str:
-    """Return OSC-8 hyperlink escape sequence."""
-    return f"\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\"
+def hyperlink(text: str, url: str, color: str = None) -> str:
+    """Return OSC-8 hyperlink escape sequence with optional ANSI color."""
+    colored_text = text
+    if color:
+        colors = {
+            "black": "30",
+            "red": "31",
+            "green": "32",
+            "yellow": "33",
+            "blue": "34",
+            "magenta": "35",
+            "cyan": "36",
+            "white": "37",
+        }
+        code = colors.get(color.lower())
+        if code:
+            colored_text = f"\x1b[{code}m{text}\x1b[0m"
+
+    return f"\x1b]8;;{url}\x1b\\{colored_text}\x1b]8;;\x1b\\"
 
 
 def get_sentiment_model():
@@ -145,13 +161,14 @@ def register_routes(app):
         user_agent = request.headers.get("User-Agent", "").lower()
         if "curl" in user_agent:
             links = "\n".join([
-                f"- {hyperlink('home', BASE_URL + url_for('index'))}",
-                f"- {hyperlink('about', BASE_URL + url_for('about'))}",
-                f"- {hyperlink('demos', BASE_URL + url_for('demos'))}",
-                f"- {hyperlink('resume', BASE_URL + url_for('resume'))}",
-                f"- {hyperlink('contact', BASE_URL + url_for('contact'))}",
+                f"- {hyperlink('home', BASE_URL + url_for('index'), color='blue')}",
+                f"- {hyperlink('about', BASE_URL + url_for('about'), color='blue')}",
+                f"- {hyperlink('demos', BASE_URL + url_for('demos'), color='blue')}",
+                f"- {hyperlink('resume', BASE_URL + url_for('resume'), color='blue')}",
+                f"- {hyperlink('contact', BASE_URL + url_for('contact'), color='blue')}",
             ])
-            return f"{ABOUT_TEXT.strip()}\n\n{links}\n"
+            intro = "For more information, follow the links below"
+            return f"{ABOUT_TEXT.strip()}\n\n{intro}\n{links}\n"
         return render_template("index.html")
 
     # Serve the favicon for browsers that request /favicon.ico

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,9 +18,13 @@ def test_index_route_curl(client):
     assert response.status_code == 200
     text = response.get_data(as_text=True)
     assert ABOUT_TEXT.strip() in text
+    assert "For more information, follow the links below" in text
+
     def osc8(label, path):
         url = f"https://erickramer.xyz{path}"
-        return f"- \x1b]8;;{url}\x1b\\{label}\x1b]8;;\x1b\\"
+        blue = "\x1b[34m"
+        reset = "\x1b[0m"
+        return f"- \x1b]8;;{url}\x1b\\{blue}{label}{reset}\x1b]8;;\x1b\\"
 
     for label, path in [
         ("home", "/"),


### PR DESCRIPTION
## Summary
- colorize OSC8 hyperlinks in curl output
- show explanatory text before curl links
- update tests for new text and color codes

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6851d3c7f1108329b1a4162fd625f0b3