### PR TITLE
Allow HTTP access to homepage

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -21,9 +21,12 @@ handlers:
   static_dir: static/dist/images
   secure: always
   expiration: 7d
+- url: /
+  script: auto
+  secure: optional
 - url: /.*
   script: auto
-  secure: always
+  secure: redirect
 env_variables:
   FLASK_APP: app.py
   FLASK_CONFIG: production


### PR DESCRIPTION
## Summary
- update app engine config to allow HTTP on the root path and redirect other routes to HTTPS

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6851d4179b908329aa31a9016e899910