### PR TITLE
Lighten curl link color

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,11 +161,11 @@ def register_routes(app):
         user_agent = request.headers.get("User-Agent", "").lower()
         if "curl" in user_agent:
             links = "\n".join([
-                f"- {hyperlink('home', BASE_URL + url_for('index'), color='blue')}",
-                f"- {hyperlink('about', BASE_URL + url_for('about'), color='blue')}",
-                f"- {hyperlink('demos', BASE_URL + url_for('demos'), color='blue')}",
-                f"- {hyperlink('resume', BASE_URL + url_for('resume'), color='blue')}",
-                f"- {hyperlink('contact', BASE_URL + url_for('contact'), color='blue')}",
+                f"- {hyperlink('home', BASE_URL + url_for('index'), color='cyan')}",
+                f"- {hyperlink('about', BASE_URL + url_for('about'), color='cyan')}",
+                f"- {hyperlink('demos', BASE_URL + url_for('demos'), color='cyan')}",
+                f"- {hyperlink('resume', BASE_URL + url_for('resume'), color='cyan')}",
+                f"- {hyperlink('contact', BASE_URL + url_for('contact'), color='cyan')}",
             ])
             intro = "For more information, follow the links below"
             return f"{ABOUT_TEXT.strip()}\n\n{intro}\n{links}\n"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -22,9 +22,9 @@ def test_index_route_curl(client):
 
     def osc8(label, path):
         url = f"https://erickramer.xyz{path}"
-        blue = "\x1b[34m"
+        cyan = "\x1b[36m"
         reset = "\x1b[0m"
-        return f"- \x1b]8;;{url}\x1b\\{blue}{label}{reset}\x1b]8;;\x1b\\"
+        return f"- \x1b]8;;{url}\x1b\\{cyan}{label}{reset}\x1b]8;;\x1b\\"
 
     for label, path in [
         ("home", "/"),


### PR DESCRIPTION
## Summary
- use cyan coloring for terminal links
- update curl link test for the new color

## Testing
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_6851d99439f483299df8b3c3d5c24d9b