### PR TITLE
Fix asteroid SVG asset path

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = (env, argv) => {
     output: {
       filename: 'js/[name].bundle.js',
       path: path.resolve(__dirname, 'dist'),
+      publicPath: '/static/dist/',
     },
     devtool: isDevelopment ? 'source-map' : false,
     module: {

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -133,6 +133,20 @@ def test_static_js_files(client, is_ci_environment):
         assert response.status_code == 200, f"JS file {js_file} not accessible"
         assert 'javascript' in response.headers['Content-Type'].lower()
 
+def test_static_image_files(client, is_ci_environment):
+    """Test that critical image files can be accessed."""
+    if is_ci_environment:
+        pytest.skip("Skipping image files in CI environment")
+
+    image_files = [
+        '/static/dist/images/spaceship.svg'
+    ]
+
+    for image_file in image_files:
+        response = client.get(image_file)
+        assert response.status_code == 200, f"Image {image_file} not accessible"
+        assert 'image' in response.headers['Content-Type']
+
 def test_debug_static_endpoint(client):
     """Test the debug static endpoint lists files correctly."""
     response = client.get('/debug/static')


### PR DESCRIPTION
## Summary
- ensure webpack outputs public path for static assets
- test spaceship SVG is accessible via `/static/dist`

## Testing
- `python -m pytest -k 'static_image_files or static_js_files' -vv`
- `make test-backend`

------
https://chatgpt.com/codex/tasks/task_e_685c463d24988329983d6928deb977ee